### PR TITLE
chore(deps): bump follow-redirects to 1.16.0 via npm override

### DIFF
--- a/dashboard/frontend/package-lock.json
+++ b/dashboard/frontend/package-lock.json
@@ -6668,9 +6668,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",

--- a/dashboard/frontend/package.json
+++ b/dashboard/frontend/package.json
@@ -11,6 +11,9 @@
     "format:check": "prettier --check .",
     "format": "prettier --write ."
   },
+  "overrides": {
+    "follow-redirects": "^1.16.0"
+  },
   "dependencies": {
     "@codemirror/lang-json": "^6.0.2",
     "@hookform/resolvers": "^5.2.2",

--- a/dashboard/frontend/yarn.lock
+++ b/dashboard/frontend/yarn.lock
@@ -2881,10 +2881,10 @@ flatted@^3.2.9:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz"
   integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
 
-follow-redirects@^1.15.11:
-  version "1.15.11"
-  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz"
-  integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
+follow-redirects@^1.16.0:
+  version "1.16.0"
+  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz"
+  integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
 
 form-data@^4.0.5:
   version "4.0.5"


### PR DESCRIPTION
## Summary

Closes #355. Addresses security advisory [GHSA-r4q5-vmmm-2653](https://github.com/advisories/GHSA-r4q5-vmmm-2653) (follow-redirects leaks custom authentication headers on cross-domain redirects) by pinning the transitive dep to ^1.16.0 through npm's \`overrides\` field.

axios 1.15.0 declares \`follow-redirects: ^1.15.6\` which resolves to 1.15.11 without the override. With the override, lockfiles resolve follow-redirects to 1.16.0.

Tier 1 (low risk) — lockfile-only for a transitive.

## Test plan

- [x] \`npm ls follow-redirects\` → 1.16.0
- [x] \`npm audit\` → 0 vulnerabilities
- [x] \`vite build\` → succeeds