### PR TITLE
fix(celery): auto-refresh Redis client on Sentinel master rotation

### DIFF
--- a/pyworkflow/celery/singleton.py
+++ b/pyworkflow/celery/singleton.py
@@ -11,8 +11,9 @@ Based on:
 
 import inspect
 import json
+from collections.abc import Callable
 from hashlib import md5
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 from uuid import uuid4
 
 from celery import Task
@@ -20,7 +21,10 @@ from celery.exceptions import WorkerLostError
 from loguru import logger
 
 if TYPE_CHECKING:
+    from redis import Redis
     from redis.sentinel import Sentinel
+
+T = TypeVar("T")
 
 
 def generate_lock_key(
@@ -74,10 +78,17 @@ class SingletonConfig:
 
 
 class RedisLockBackend:
-    """Redis backend for distributed locking with Sentinel support."""
+    """Redis backend for distributed locking with Sentinel support.
+
+    During Sentinel failover (master rotation), cached connections can raise
+    MasterNotFoundError or socket TimeoutError. On those, we refresh the client
+    via ``sentinel.master_for()`` and retry the operation once. See
+    ``_execute_with_refresh``.
+    """
 
     _sentinel: "Sentinel | None"
     _master_name: str | None
+    redis: "Redis"
 
     def __init__(
         self,
@@ -91,20 +102,61 @@ class RedisLockBackend:
             from redis.sentinel import Sentinel
 
             sentinels = self._parse_sentinel_url(url)
+            # socket_timeout=5 matches FlowHunt's production-tested value.
+            # The previous 0.5s was too tight during Sentinel failover windows.
             self._sentinel = Sentinel(
                 sentinels,
-                socket_timeout=0.5,
+                socket_timeout=5,
                 decode_responses=True,
             )
             self._master_name = sentinel_master or "mymaster"
-            self.redis = self._sentinel.master_for(
-                self._master_name,
-                decode_responses=True,
-            )
+            self.redis = self._build_master_client()
         else:
             self._sentinel = None
             self._master_name = None
             self.redis = redis.from_url(url, decode_responses=True)
+
+    def _build_master_client(self) -> "Redis":
+        """Get a fresh master client from Sentinel. Sentinel mode only."""
+        assert self._sentinel is not None and self._master_name is not None
+        return self._sentinel.master_for(
+            self._master_name,
+            decode_responses=True,
+        )
+
+    def _refresh_client(self) -> None:
+        """Re-resolve master via Sentinel after a failover-related error."""
+        if self._sentinel is None:
+            return
+        self.redis = self._build_master_client()
+        logger.info(
+            "Refreshed Redis master connection for sentinel master '{}'",
+            self._master_name,
+        )
+
+    def _execute_with_refresh(self, fn: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+        """Run ``fn``; on Sentinel failover errors, refresh the client and retry once.
+
+        In non-sentinel mode this is a no-op passthrough — refresh has nothing
+        to do, so any exception propagates as before.
+        """
+        from redis.exceptions import ConnectionError as RedisConnectionError
+        from redis.exceptions import TimeoutError as RedisTimeoutError
+        from redis.sentinel import MasterNotFoundError
+
+        try:
+            return fn(*args, **kwargs)
+        except (MasterNotFoundError, RedisConnectionError, RedisTimeoutError) as exc:
+            if self._sentinel is None:
+                raise
+            logger.warning(
+                "Redis lock op hit sentinel failover error ({}: {}). "
+                "Refreshing master and retrying once.",
+                type(exc).__name__,
+                exc,
+            )
+            self._refresh_client()
+            return fn(*args, **kwargs)
 
     @staticmethod
     def _parse_sentinel_url(url: str) -> list[tuple[str, int]]:
@@ -142,15 +194,19 @@ class RedisLockBackend:
 
     def lock(self, lock_key: str, task_id: str, expiry: int | None = None) -> bool:
         """Acquire lock atomically. Returns True if acquired."""
-        return bool(self.redis.set(lock_key, task_id, nx=True, ex=expiry))
+        return bool(
+            self._execute_with_refresh(
+                lambda: self.redis.set(lock_key, task_id, nx=True, ex=expiry)
+            )
+        )
 
     def unlock(self, lock_key: str) -> None:
         """Release the lock."""
-        self.redis.delete(lock_key)
+        self._execute_with_refresh(lambda: self.redis.delete(lock_key))
 
     def get(self, lock_key: str) -> str | None:
         """Get the task ID holding the lock."""
-        return self.redis.get(lock_key)
+        return self._execute_with_refresh(lambda: self.redis.get(lock_key))
 
 
 class DuplicateTaskError(Exception):

--- a/tests/unit/test_singleton.py
+++ b/tests/unit/test_singleton.py
@@ -785,6 +785,132 @@ class TestRedisLockBackendSentinel:
             assert backend._sentinel is None
 
 
+class TestRedisLockBackendAutoRefresh:
+    """Sentinel failover recovery in RedisLockBackend.
+
+    When the Sentinel master rotates, the cached Redis client can raise
+    ``MasterNotFoundError`` or ``TimeoutError``. The backend should transparently
+    refresh the client via ``sentinel.master_for()`` and retry the operation once.
+    """
+
+    def _make_sentinel_backend(self, mock_sentinel_class, stale_client, fresh_client):
+        """Build a sentinel-backed backend where master_for returns stale then fresh."""
+        mock_sentinel = mock_sentinel_class.return_value
+        mock_sentinel.master_for.side_effect = [stale_client, fresh_client]
+
+        return RedisLockBackend(
+            "sentinel://host1:26379/0",
+            is_sentinel=True,
+            sentinel_master="mymaster",
+        )
+
+    def test_lock_recovers_from_master_not_found(self):
+        """MasterNotFoundError on lock() triggers refresh and succeeds on retry."""
+        from redis.sentinel import MasterNotFoundError
+
+        with patch("redis.sentinel.Sentinel") as mock_sentinel_class:
+            stale = MagicMock()
+            stale.set.side_effect = MasterNotFoundError("No master found for 'mymaster'")
+            fresh = MagicMock()
+            fresh.set.return_value = True
+
+            backend = self._make_sentinel_backend(mock_sentinel_class, stale, fresh)
+            result = backend.lock("test_key", "task_123", expiry=3600)
+
+            assert result is True
+            stale.set.assert_called_once()
+            fresh.set.assert_called_once_with("test_key", "task_123", nx=True, ex=3600)
+            # master_for called twice: initial + refresh
+            assert mock_sentinel_class.return_value.master_for.call_count == 2
+
+    def test_lock_recovers_from_timeout_error(self):
+        """Redis TimeoutError on lock() triggers refresh and succeeds on retry."""
+        from redis.exceptions import TimeoutError as RedisTimeoutError
+
+        with patch("redis.sentinel.Sentinel") as mock_sentinel_class:
+            stale = MagicMock()
+            stale.set.side_effect = RedisTimeoutError("Timeout reading from socket")
+            fresh = MagicMock()
+            fresh.set.return_value = True
+
+            backend = self._make_sentinel_backend(mock_sentinel_class, stale, fresh)
+            result = backend.lock("test_key", "task_123", expiry=3600)
+
+            assert result is True
+            assert mock_sentinel_class.return_value.master_for.call_count == 2
+
+    def test_lock_recovers_from_connection_error(self):
+        """Redis ConnectionError on lock() triggers refresh and succeeds on retry."""
+        from redis.exceptions import ConnectionError as RedisConnectionError
+
+        with patch("redis.sentinel.Sentinel") as mock_sentinel_class:
+            stale = MagicMock()
+            stale.set.side_effect = RedisConnectionError("Connection reset by peer")
+            fresh = MagicMock()
+            fresh.set.return_value = True
+
+            backend = self._make_sentinel_backend(mock_sentinel_class, stale, fresh)
+            assert backend.lock("test_key", "task_123", expiry=3600) is True
+            assert mock_sentinel_class.return_value.master_for.call_count == 2
+
+    def test_unlock_recovers_from_master_rotation(self):
+        """unlock() refreshes and retries once on Sentinel failover errors."""
+        from redis.sentinel import MasterNotFoundError
+
+        with patch("redis.sentinel.Sentinel") as mock_sentinel_class:
+            stale = MagicMock()
+            stale.delete.side_effect = MasterNotFoundError("No master found")
+            fresh = MagicMock()
+
+            backend = self._make_sentinel_backend(mock_sentinel_class, stale, fresh)
+            backend.unlock("test_key")
+
+            fresh.delete.assert_called_once_with("test_key")
+
+    def test_get_recovers_from_master_rotation(self):
+        """get() refreshes and retries once on Sentinel failover errors."""
+        from redis.sentinel import MasterNotFoundError
+
+        with patch("redis.sentinel.Sentinel") as mock_sentinel_class:
+            stale = MagicMock()
+            stale.get.side_effect = MasterNotFoundError("No master found")
+            fresh = MagicMock()
+            fresh.get.return_value = "task_123"
+
+            backend = self._make_sentinel_backend(mock_sentinel_class, stale, fresh)
+            assert backend.get("test_key") == "task_123"
+
+    def test_second_attempt_failure_propagates(self):
+        """If the retry also fails, the exception propagates."""
+        from redis.sentinel import MasterNotFoundError
+
+        with patch("redis.sentinel.Sentinel") as mock_sentinel_class:
+            stale = MagicMock()
+            stale.set.side_effect = MasterNotFoundError("No master found")
+            fresh = MagicMock()
+            fresh.set.side_effect = MasterNotFoundError("Still no master")
+
+            backend = self._make_sentinel_backend(mock_sentinel_class, stale, fresh)
+            with pytest.raises(MasterNotFoundError):
+                backend.lock("test_key", "task_123", expiry=3600)
+
+    def test_non_sentinel_mode_does_not_refresh(self):
+        """Non-sentinel backend has no refresh path — exceptions propagate."""
+        from redis.sentinel import MasterNotFoundError
+
+        with patch("redis.from_url") as mock_from_url:
+            mock_redis = MagicMock()
+            mock_redis.set.side_effect = MasterNotFoundError("No master found")
+            mock_from_url.return_value = mock_redis
+
+            backend = RedisLockBackend("redis://localhost:6379/0")
+            with pytest.raises(MasterNotFoundError):
+                backend.lock("test_key", "task_123", expiry=3600)
+
+            # Only the initial resolution — no refresh attempts.
+            assert mock_redis.set.call_count == 1
+
+
 class TestSingletonConfigSentinel:
     """Test SingletonConfig Sentinel properties."""
 


### PR DESCRIPTION
## Summary
- Wrap `RedisLockBackend.lock/unlock/get` in `_execute_with_refresh`: on `MasterNotFoundError`, `ConnectionError`, or `TimeoutError` while in Sentinel mode, re-resolve the master via `sentinel.master_for()` and retry the op once. Non-sentinel mode is unchanged.
- Bump Sentinel `socket_timeout` from `0.5` to `5` (matches FlowHunt's production-tested value); `500ms` was too tight during failover windows.
- 7 new unit tests covering the failover-recovery paths.

## Why
Fixes QualityUnit/urlslab-app#5319. When the Sentinel master rotates, the cached Redis client in `RedisLockBackend` raises `MasterNotFoundError` or `TimeoutError('Timeout reading from socket')` on the next lock op, propagating up through `apply_async → acquire_lock` and surfacing the raw exception to end users. Mirrors the battle-tested pattern already used in FlowHunt (`AutoRefreshRedisClientBase`).

## Risk tier
**Tier 2** — touches `pyworkflow/celery/singleton.py`. Not on the Tier 3 list in `CLAUDE.md`, but singleton locking runs on every task dispatch, so I've added focused unit tests around the new behavior.

## Test plan
- [x] `pytest tests/unit/test_singleton.py` — 61/61 passing (7 new)
- [x] `pytest tests/unit` — 831/831 passing
- [x] `ruff check` — clean on changed files
- [x] `black --check` — clean on changed files
- [x] `mypy pyworkflow/celery/singleton.py` — no new errors (pre-existing mypy errors elsewhere unchanged)
- [ ] Manual validation: verify in a FlowHunt staging pod with Sentinel failover that the `No master found` error no longer surfaces to end users

## Component
`celery` (singleton locking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)