### PR TITLE
fix(storage): project summary columns + keyset pagination in list_runs (#482)

### DIFF
--- a/dashboard/backend/app/rest/v1/runs.py
+++ b/dashboard/backend/app/rest/v1/runs.py
@@ -28,7 +28,7 @@ async def list_runs(
     end_time: datetime | None = Query(
         None, description="Filter runs started before this time (ISO 8601)"
     ),
-    limit: int = Query(100, ge=1, le=1000, description="Maximum results"),
+    limit: int = Query(100, ge=1, le=200, description="Maximum results"),
     cursor: str | None = Query(None, description="Run ID to start after (for pagination)"),
     storage: StorageBackend = Depends(get_storage),
 ) -> RunListResponse:

--- a/dashboard/frontend/src/features/runs/components/runs-table.tsx
+++ b/dashboard/frontend/src/features/runs/components/runs-table.tsx
@@ -57,6 +57,9 @@ interface RunsTableProps {
   onDateRangeChange?: (range: DateRange) => void
   filters?: RunsFilters
   onFiltersChange?: (filters: RunsFilters) => void
+  hasNextPage?: boolean
+  isFetchingNextPage?: boolean
+  onLoadMore?: () => void
 }
 
 function formatDuration(seconds: number | null): string {
@@ -89,6 +92,9 @@ export function RunsTable({
   onDateRangeChange,
   filters,
   onFiltersChange,
+  hasNextPage,
+  isFetchingNextPage,
+  onLoadMore,
 }: RunsTableProps) {
   const navigate = useNavigate()
   const [sorting, setSorting] = useState<SortingState>([
@@ -551,7 +557,20 @@ export function RunsTable({
         </div>
       </div>
 
-      <DataTablePagination table={table} className="mt-auto" />
+      <div className="mt-auto flex items-center justify-between gap-4">
+        <DataTablePagination table={table} className="flex-1" />
+        {hasNextPage && onLoadMore && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8"
+            onClick={onLoadMore}
+            disabled={isFetchingNextPage}
+          >
+            {isFetchingNextPage ? 'Loading...' : 'Load more'}
+          </Button>
+        )}
+      </div>
     </div>
   )
 }

--- a/dashboard/frontend/src/features/runs/index.tsx
+++ b/dashboard/frontend/src/features/runs/index.tsx
@@ -11,8 +11,13 @@ import { GithubStarButton } from '@/components/github-star-button'
 import { ThemeSwitch } from '@/components/theme-switch'
 import { RefreshButton } from '@/components/refresh-button'
 import { Badge } from '@/components/ui/badge'
-import { useRuns, REFRESH_INTERVAL } from '@/hooks/use-runs'
+import { Button } from '@/components/ui/button'
+import { useRunsInfinite, REFRESH_INTERVAL } from '@/hooks/use-runs'
 import { RunsTable } from './components/runs-table'
+
+// Page size for cursor-paginated fetches. Kept small so the dashboard never scatter-gathers the
+// whole runs table on every poll (issue #482); additional pages load on demand.
+const RUNS_PAGE_SIZE = 100
 
 export interface DateRange {
   from: Date | null
@@ -55,7 +60,7 @@ export function RunsList({ query }: RunsListProps) {
       start_time?: string
       end_time?: string
     } = {
-      limit: 1000,
+      limit: RUNS_PAGE_SIZE,
     }
 
     // Use URL query param if provided, otherwise use search filter
@@ -84,11 +89,24 @@ export function RunsList({ query }: RunsListProps) {
     return params
   }, [query, filters.searchQuery, filters.statusFilter, filters.workflowFilter, dateRange.from, dateRange.to, fromTime, toTime])
 
-  // Fetch runs with server-side filtering
-  const { data, isLoading, isFetching, error, refetch } = useRuns({
+  // Fetch runs with server-side filtering and cursor pagination
+  const {
+    data,
+    isLoading,
+    isFetching,
+    error,
+    refetch,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useRunsInfinite({
     params: apiParams,
     autoRefresh: autoRefreshEnabled,
   })
+
+  // Flatten the cursor-paginated pages into a single list for the table.
+  const runs = useMemo(() => data?.pages.flatMap((page) => page.items) ?? [], [data])
+  const loadedCount = runs.length
 
   const clearQueryFilter = () => {
     navigate({ to: '/runs', search: {} })
@@ -132,7 +150,9 @@ export function RunsList({ query }: RunsListProps) {
               {query ? `Search: ${query}` : 'Workflow Runs'}
             </h2>
             <p className="text-muted-foreground">
-              {data ? `${data.count} run${data.count !== 1 ? 's' : ''}` : 'Loading...'}
+              {data
+                ? `${loadedCount}${hasNextPage ? '+' : ''} run${loadedCount !== 1 ? 's' : ''}`
+                : 'Loading...'}
             </p>
           </div>
           {query && (
@@ -164,12 +184,15 @@ export function RunsList({ query }: RunsListProps) {
           <div className="-mx-4 flex-1 overflow-auto px-4 py-1 lg:flex-row lg:space-x-12 lg:space-y-0">
             <div className="@container/content h-full">
               <RunsTable
-                runs={data.items}
+                runs={runs}
                 onPageChange={handlePageChange}
                 dateRange={dateRange}
                 onDateRangeChange={setDateRange}
                 filters={filters}
                 onFiltersChange={handleFiltersChange}
+                hasNextPage={hasNextPage}
+                isFetchingNextPage={isFetchingNextPage}
+                onLoadMore={() => fetchNextPage()}
               />
             </div>
           </div>

--- a/dashboard/frontend/src/hooks/use-runs.ts
+++ b/dashboard/frontend/src/hooks/use-runs.ts
@@ -2,7 +2,7 @@
  * React Query hooks for workflow runs.
  */
 
-import { useQuery, keepPreviousData } from '@tanstack/react-query'
+import { useQuery, useInfiniteQuery, keepPreviousData } from '@tanstack/react-query'
 import {
   listRuns,
   getRun,
@@ -37,6 +37,23 @@ export function useRuns({ params = {}, autoRefresh = true }: UseRunsOptions = {}
     refetchInterval: autoRefresh ? REFRESH_INTERVAL : false,
     refetchOnWindowFocus: false,
     placeholderData: keepPreviousData,
+  })
+}
+
+/**
+ * Cursor-paginated runs list. Each page fetches a bounded number of summary rows (see `limit` in
+ * params) and follows `next_cursor` for subsequent pages, so the Runs page never fetches the whole
+ * table at once (issue #482). Auto-refresh only re-fetches already-loaded pages.
+ */
+export function useRunsInfinite({ params = {}, autoRefresh = true }: UseRunsOptions = {}) {
+  return useInfiniteQuery({
+    queryKey: ['runs-infinite', params],
+    queryFn: ({ pageParam }) =>
+      listRuns({ ...params, cursor: pageParam as string | undefined }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.next_cursor ?? undefined,
+    refetchInterval: autoRefresh ? REFRESH_INTERVAL : false,
+    refetchOnWindowFocus: false,
   })
 }
 

--- a/pyworkflow/storage/citus.py
+++ b/pyworkflow/storage/citus.py
@@ -308,17 +308,13 @@ class CitusStorageBackend(PostgresStorageBackend):
             await conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_runs_created_at ON workflow_runs(created_at DESC)"
             )
-            # Covering index backing the unfiltered Runs list (issue #482): keyset order is
-            # (created_at DESC, run_id DESC) and the INCLUDE columns are exactly the summary
-            # projection (RUN_SUMMARY_COLUMNS) minus the key columns, so each shard can answer the
-            # scatter-gather from an index-only scan instead of heap-fetching wide rows.
+            # Composite index backing keyset pagination + ORDER BY created_at DESC, run_id DESC
+            # for the unfiltered Runs list (issue #482). The summary column projection
+            # (RUN_SUMMARY_COLUMNS) already drops the heavy payload columns from the scatter-gather;
+            # no INCLUDE covering columns, to avoid duplicating the summary columns into the index.
             await conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_runs_created_at_run_id "
-                "ON workflow_runs(created_at DESC, run_id DESC) "
-                "INCLUDE (workflow_name, status, updated_at, started_at, completed_at, error, "
-                "idempotency_key, max_duration, recovery_attempts, max_recovery_attempts, "
-                "recover_on_worker_loss, parent_run_id, nesting_depth, continued_from_run_id, "
-                "continued_to_run_id)"
+                "ON workflow_runs(created_at DESC, run_id DESC)"
             )
             # Non-unique index: Citus cannot enforce global uniqueness on non-distribution columns
             await conn.execute(

--- a/pyworkflow/storage/citus.py
+++ b/pyworkflow/storage/citus.py
@@ -308,6 +308,18 @@ class CitusStorageBackend(PostgresStorageBackend):
             await conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_runs_created_at ON workflow_runs(created_at DESC)"
             )
+            # Covering index backing the unfiltered Runs list (issue #482): keyset order is
+            # (created_at DESC, run_id DESC) and the INCLUDE columns are exactly the summary
+            # projection (RUN_SUMMARY_COLUMNS) minus the key columns, so each shard can answer the
+            # scatter-gather from an index-only scan instead of heap-fetching wide rows.
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_runs_created_at_run_id "
+                "ON workflow_runs(created_at DESC, run_id DESC) "
+                "INCLUDE (workflow_name, status, updated_at, started_at, completed_at, error, "
+                "idempotency_key, max_duration, recovery_attempts, max_recovery_attempts, "
+                "recover_on_worker_loss, parent_run_id, nesting_depth, continued_from_run_id, "
+                "continued_to_run_id)"
+            )
             # Non-unique index: Citus cannot enforce global uniqueness on non-distribution columns
             await conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_runs_idempotency_key ON workflow_runs(idempotency_key) WHERE idempotency_key IS NOT NULL"

--- a/pyworkflow/storage/mysql.py
+++ b/pyworkflow/storage/mysql.py
@@ -31,6 +31,15 @@ from pyworkflow.storage.schemas import (
     WorkflowRun,
 )
 
+# Columns needed by list/summary views. Excludes the heavy payload columns
+# (input_args, input_kwargs, result, metadata) which a list view never renders. See issue #482.
+RUN_SUMMARY_COLUMNS = (
+    "run_id, workflow_name, status, created_at, updated_at, started_at, completed_at, "
+    "error, idempotency_key, max_duration, recovery_attempts, max_recovery_attempts, "
+    "recover_on_worker_loss, parent_run_id, nesting_depth, continued_from_run_id, "
+    "continued_to_run_id"
+)
+
 
 class MySQLMigrationRunner(MigrationRunner):
     """MySQL-specific migration runner."""
@@ -286,6 +295,7 @@ class MySQLStorageBackend(StorageBackend):
                         INDEX idx_runs_status (status),
                         INDEX idx_runs_workflow_name (workflow_name),
                         INDEX idx_runs_created_at (created_at DESC),
+                        INDEX idx_runs_created_at_run_id (created_at DESC, run_id DESC),
                         UNIQUE INDEX idx_runs_idempotency_key (idempotency_key),
                         INDEX idx_runs_parent_run_id (parent_run_id),
                         FOREIGN KEY (parent_run_id) REFERENCES workflow_runs(run_id)
@@ -607,15 +617,23 @@ class MySQLStorageBackend(StorageBackend):
         limit: int = 100,
         cursor: str | None = None,
     ) -> tuple[list[WorkflowRun], str | None]:
-        """List workflow runs with optional filtering and pagination."""
+        """List workflow runs with optional filtering and pagination.
+
+        Note: the returned WorkflowRun objects are *summaries* — the heavy payload columns
+        (input_args, input_kwargs, result, metadata) are NOT fetched and carry placeholder
+        defaults. Use get_run() when the full payload is required. See issue #482.
+        """
         pool = self._ensure_connected()
 
         conditions = []
         params: list[Any] = []
 
         if cursor:
+            # Keyset pagination on (created_at, run_id) — created_at is not unique, so paginating on
+            # it alone would skip/duplicate rows sharing a timestamp. See issue #482.
             conditions.append(
-                "created_at < (SELECT created_at FROM workflow_runs WHERE run_id = %s)"
+                "(created_at, run_id) < "
+                "(SELECT created_at, run_id FROM workflow_runs WHERE run_id = %s)"
             )
             params.append(cursor)
 
@@ -640,9 +658,9 @@ class MySQLStorageBackend(StorageBackend):
         params.append(limit + 1)  # Fetch one extra to determine if there are more
 
         sql = f"""
-            SELECT * FROM workflow_runs
+            SELECT {RUN_SUMMARY_COLUMNS} FROM workflow_runs
             {where_clause}
-            ORDER BY created_at DESC
+            ORDER BY created_at DESC, run_id DESC
             LIMIT %s
         """
 
@@ -654,7 +672,7 @@ class MySQLStorageBackend(StorageBackend):
         if has_more:
             rows = rows[:limit]
 
-        runs = [self._row_to_workflow_run(row) for row in rows]
+        runs = [self._row_to_workflow_run_summary(row) for row in rows]
         next_cursor = runs[-1].run_id if runs and has_more else None
 
         return runs, next_cursor
@@ -1477,6 +1495,36 @@ class MySQLStorageBackend(StorageBackend):
             idempotency_key=row["idempotency_key"],
             max_duration=row["max_duration"],
             context=json.loads(row["metadata"]) if row["metadata"] else {},
+            recovery_attempts=row["recovery_attempts"],
+            max_recovery_attempts=row["max_recovery_attempts"],
+            recover_on_worker_loss=bool(row["recover_on_worker_loss"]),
+            parent_run_id=row["parent_run_id"],
+            nesting_depth=row["nesting_depth"],
+            continued_from_run_id=row["continued_from_run_id"],
+            continued_to_run_id=row["continued_to_run_id"],
+        )
+
+    def _row_to_workflow_run_summary(self, row: dict) -> WorkflowRun:
+        """Convert a summary row (RUN_SUMMARY_COLUMNS) to a WorkflowRun.
+
+        Heavy payload columns are not selected by list_runs, so they are filled with their schema
+        defaults. Callers needing the real payload must use get_run(). See issue #482.
+        """
+        return WorkflowRun(
+            run_id=row["run_id"],
+            workflow_name=row["workflow_name"],
+            status=RunStatus(row["status"]),
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+            started_at=row["started_at"],
+            completed_at=row["completed_at"],
+            input_args="[]",
+            input_kwargs="{}",
+            result=None,
+            error=row["error"],
+            idempotency_key=row["idempotency_key"],
+            max_duration=row["max_duration"],
+            context={},
             recovery_attempts=row["recovery_attempts"],
             max_recovery_attempts=row["max_recovery_attempts"],
             recover_on_worker_loss=bool(row["recover_on_worker_loss"]),

--- a/pyworkflow/storage/postgres.py
+++ b/pyworkflow/storage/postgres.py
@@ -39,6 +39,17 @@ from pyworkflow.storage.schemas import (
     WorkflowRun,
 )
 
+# Columns needed by list/summary views (the Runs list, CLI table). Deliberately excludes the heavy
+# unbounded payload columns (input_args, input_kwargs, result, metadata) which a list view never
+# renders. Selecting only these avoids scatter-gathering wide rows across every Citus shard.
+# See issue #482. Keep `error` — it is shown in the list view and is normally short.
+RUN_SUMMARY_COLUMNS = (
+    "run_id, workflow_name, status, created_at, updated_at, started_at, completed_at, "
+    "error, idempotency_key, max_duration, recovery_attempts, max_recovery_attempts, "
+    "recover_on_worker_loss, parent_run_id, nesting_depth, continued_from_run_id, "
+    "continued_to_run_id"
+)
+
 
 class PostgresMigrationRunner(MigrationRunner):
     """PostgreSQL-specific migration runner."""
@@ -428,6 +439,12 @@ class PostgresStorageBackend(StorageBackend):
             )
             await conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_runs_created_at ON workflow_runs(created_at DESC)"
+            )
+            # Composite index backing keyset pagination + ORDER BY created_at DESC, run_id DESC
+            # (see list_runs / issue #482).
+            await conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_runs_created_at_run_id "
+                "ON workflow_runs(created_at DESC, run_id DESC)"
             )
             await conn.execute(
                 "CREATE UNIQUE INDEX IF NOT EXISTS idx_runs_idempotency_key ON workflow_runs(idempotency_key) WHERE idempotency_key IS NOT NULL"
@@ -852,7 +869,12 @@ class PostgresStorageBackend(StorageBackend):
         limit: int = 100,
         cursor: str | None = None,
     ) -> tuple[list[WorkflowRun], str | None]:
-        """List workflow runs with optional filtering and pagination."""
+        """List workflow runs with optional filtering and pagination.
+
+        Note: the returned WorkflowRun objects are *summaries* — the heavy payload columns
+        (input_args, input_kwargs, result, metadata) are NOT fetched and carry placeholder
+        defaults. Use get_run() when the full payload is required. See issue #482.
+        """
         pool = await self._get_pool()
 
         conditions = []
@@ -860,8 +882,12 @@ class PostgresStorageBackend(StorageBackend):
         param_idx = 1
 
         if cursor:
+            # Keyset pagination on (created_at, run_id). created_at is not unique, so paginating on
+            # it alone would skip/duplicate rows that share a timestamp. The composite tuple compare
+            # is a stable total order matching ORDER BY created_at DESC, run_id DESC.
             conditions.append(
-                f"created_at < (SELECT created_at FROM workflow_runs WHERE run_id = ${param_idx})"
+                f"(created_at, run_id) < "
+                f"(SELECT created_at, run_id FROM workflow_runs WHERE run_id = ${param_idx})"
             )
             params.append(cursor)
             param_idx += 1
@@ -893,9 +919,9 @@ class PostgresStorageBackend(StorageBackend):
         params.append(limit + 1)  # Fetch one extra to determine if there are more
 
         sql = f"""
-            SELECT * FROM workflow_runs
+            SELECT {RUN_SUMMARY_COLUMNS} FROM workflow_runs
             {where_clause}
-            ORDER BY created_at DESC
+            ORDER BY created_at DESC, run_id DESC
             LIMIT ${param_idx}
         """
 
@@ -906,7 +932,7 @@ class PostgresStorageBackend(StorageBackend):
         if has_more:
             rows = rows[:limit]
 
-        runs = [self._row_to_workflow_run(row) for row in rows]
+        runs = [self._row_to_workflow_run_summary(row) for row in rows]
         next_cursor = runs[-1].run_id if runs and has_more else None
 
         return runs, next_cursor
@@ -1738,6 +1764,36 @@ class PostgresStorageBackend(StorageBackend):
             idempotency_key=row["idempotency_key"],
             max_duration=row["max_duration"],
             context=json.loads(row["metadata"]) if row["metadata"] else {},
+            recovery_attempts=row["recovery_attempts"],
+            max_recovery_attempts=row["max_recovery_attempts"],
+            recover_on_worker_loss=row["recover_on_worker_loss"],
+            parent_run_id=row["parent_run_id"],
+            nesting_depth=row["nesting_depth"],
+            continued_from_run_id=row["continued_from_run_id"],
+            continued_to_run_id=row["continued_to_run_id"],
+        )
+
+    def _row_to_workflow_run_summary(self, row: asyncpg.Record) -> WorkflowRun:
+        """Convert a summary row (RUN_SUMMARY_COLUMNS) to a WorkflowRun.
+
+        The heavy payload columns are not selected by list_runs, so they are filled with their
+        schema defaults. Callers needing the real payload must use get_run(). See issue #482.
+        """
+        return WorkflowRun(
+            run_id=row["run_id"],
+            workflow_name=row["workflow_name"],
+            status=RunStatus(row["status"]),
+            created_at=row["created_at"],
+            updated_at=row["updated_at"],
+            started_at=row["started_at"],
+            completed_at=row["completed_at"],
+            input_args="[]",
+            input_kwargs="{}",
+            result=None,
+            error=row["error"],
+            idempotency_key=row["idempotency_key"],
+            max_duration=row["max_duration"],
+            context={},
             recovery_attempts=row["recovery_attempts"],
             max_recovery_attempts=row["max_recovery_attempts"],
             recover_on_worker_loss=row["recover_on_worker_loss"],

--- a/pyworkflow/storage/sqlite.py
+++ b/pyworkflow/storage/sqlite.py
@@ -31,6 +31,16 @@ from pyworkflow.storage.schemas import (
     WorkflowRun,
 )
 
+# Columns needed by list/summary views, in the exact order consumed by
+# _row_to_workflow_run_summary (positional). Excludes the heavy payload columns
+# (input_args, input_kwargs, result, metadata) which a list view never renders. See issue #482.
+RUN_SUMMARY_COLUMNS = (
+    "run_id, workflow_name, status, created_at, updated_at, started_at, completed_at, "
+    "error, idempotency_key, max_duration, recovery_attempts, max_recovery_attempts, "
+    "recover_on_worker_loss, parent_run_id, nesting_depth, continued_from_run_id, "
+    "continued_to_run_id"
+)
+
 
 class SQLiteMigrationRunner(MigrationRunner):
     """SQLite-specific migration runner."""
@@ -248,6 +258,12 @@ class SQLiteStorageBackend(StorageBackend):
         )
         await db.execute(
             "CREATE INDEX IF NOT EXISTS idx_runs_created_at ON workflow_runs(created_at DESC)"
+        )
+        # Composite index backing keyset pagination + ORDER BY created_at DESC, run_id DESC
+        # (see list_runs / issue #482).
+        await db.execute(
+            "CREATE INDEX IF NOT EXISTS idx_runs_created_at_run_id "
+            "ON workflow_runs(created_at DESC, run_id DESC)"
         )
         await db.execute(
             "CREATE UNIQUE INDEX IF NOT EXISTS idx_runs_idempotency_key ON workflow_runs(idempotency_key) WHERE idempotency_key IS NOT NULL"
@@ -597,15 +613,24 @@ class SQLiteStorageBackend(StorageBackend):
         limit: int = 100,
         cursor: str | None = None,
     ) -> tuple[list[WorkflowRun], str | None]:
-        """List workflow runs with optional filtering and pagination."""
+        """List workflow runs with optional filtering and pagination.
+
+        Note: the returned WorkflowRun objects are *summaries* — the heavy payload columns
+        (input_args, input_kwargs, result, metadata) are NOT fetched and carry placeholder
+        defaults. Use get_run() when the full payload is required. See issue #482.
+        """
         db = self._ensure_connected()
 
         conditions = []
         params: list[Any] = []
 
         if cursor:
+            # Keyset pagination on (created_at, run_id) — created_at is not unique, so paginating on
+            # it alone would skip/duplicate rows sharing a timestamp. SQLite supports row-value
+            # comparison (>= 3.15). See issue #482.
             conditions.append(
-                "created_at < (SELECT created_at FROM workflow_runs WHERE run_id = ?)"
+                "(created_at, run_id) < "
+                "(SELECT created_at, run_id FROM workflow_runs WHERE run_id = ?)"
             )
             params.append(cursor)
 
@@ -630,9 +655,9 @@ class SQLiteStorageBackend(StorageBackend):
         params.append(limit + 1)  # Fetch one extra to determine if there are more
 
         sql = f"""
-            SELECT * FROM workflow_runs
+            SELECT {RUN_SUMMARY_COLUMNS} FROM workflow_runs
             {where_clause}
-            ORDER BY created_at DESC
+            ORDER BY created_at DESC, run_id DESC
             LIMIT ?
         """
 
@@ -643,7 +668,7 @@ class SQLiteStorageBackend(StorageBackend):
         if has_more:
             rows = rows[:limit]
 
-        runs = [self._row_to_workflow_run(row) for row in rows]
+        runs = [self._row_to_workflow_run_summary(row) for row in rows]
         next_cursor = runs[-1].run_id if runs and has_more else None
 
         return runs, next_cursor
@@ -1799,6 +1824,37 @@ class SQLiteStorageBackend(StorageBackend):
             nesting_depth=row[18],
             continued_from_run_id=row[19],
             continued_to_run_id=row[20],
+        )
+
+    def _row_to_workflow_run_summary(self, row: Any) -> WorkflowRun:
+        """Convert a summary row to a WorkflowRun.
+
+        Positional mapping MUST match the order of RUN_SUMMARY_COLUMNS. The heavy payload columns
+        are not selected by list_runs, so they are filled with their schema defaults. Callers
+        needing the real payload must use get_run(). See issue #482.
+        """
+        return WorkflowRun(
+            run_id=row[0],
+            workflow_name=row[1],
+            status=RunStatus(row[2]),
+            created_at=datetime.fromisoformat(row[3]),
+            updated_at=datetime.fromisoformat(row[4]),
+            started_at=datetime.fromisoformat(row[5]) if row[5] else None,
+            completed_at=datetime.fromisoformat(row[6]) if row[6] else None,
+            input_args="[]",
+            input_kwargs="{}",
+            result=None,
+            error=row[7],
+            idempotency_key=row[8],
+            max_duration=row[9],
+            context={},
+            recovery_attempts=row[10],
+            max_recovery_attempts=row[11],
+            recover_on_worker_loss=bool(row[12]),
+            parent_run_id=row[13],
+            nesting_depth=row[14],
+            continued_from_run_id=row[15],
+            continued_to_run_id=row[16],
         )
 
     def _row_to_event(self, row: Any) -> Event:

--- a/tests/integration/test_list_runs_pagination.py
+++ b/tests/integration/test_list_runs_pagination.py
@@ -1,0 +1,94 @@
+"""
+Integration tests for list_runs keyset pagination and summary projection (issue #482).
+
+Run against a real SQLite database so we exercise the actual SQL (row-value cursor comparison,
+ORDER BY created_at DESC, run_id DESC, and the summary column projection) rather than mocks.
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from pyworkflow.storage.schemas import RunStatus, WorkflowRun
+from pyworkflow.storage.sqlite import SQLiteStorageBackend
+
+
+@pytest.fixture
+async def storage(tmp_path):
+    """Real SQLite backend backed by a temp file."""
+    backend = SQLiteStorageBackend(db_path=str(tmp_path / "runs.db"))
+    await backend.connect()
+    yield backend
+    await backend.disconnect()
+
+
+async def _make_run(storage, run_id: str, created_at: datetime, **kwargs) -> None:
+    run = WorkflowRun(
+        run_id=run_id,
+        workflow_name="wf",
+        status=RunStatus.COMPLETED,
+        created_at=created_at,
+        updated_at=created_at,
+        **kwargs,
+    )
+    await storage.create_run(run)
+
+
+@pytest.mark.asyncio
+async def test_list_runs_keyset_pagination_handles_tied_created_at(storage):
+    """Rows sharing one created_at must each appear exactly once across cursor pages.
+
+    The old `created_at < cursor.created_at` predicate skipped/duplicated rows on ties; the keyset
+    `(created_at, run_id)` predicate must page through all of them.
+    """
+    ts = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+    # Five runs, all with the SAME created_at — the pathological tie case.
+    run_ids = {f"run_{i}" for i in range(5)}
+    for run_id in run_ids:
+        await _make_run(storage, run_id, ts)
+
+    seen: list[str] = []
+    cursor = None
+    for _ in range(10):  # generous upper bound; should terminate well before this
+        runs, cursor = await storage.list_runs(limit=2, cursor=cursor)
+        seen.extend(r.run_id for r in runs)
+        if cursor is None:
+            break
+
+    assert sorted(seen) == sorted(run_ids)  # every row exactly once, no skips/dupes
+    assert len(seen) == len(set(seen))
+
+
+@pytest.mark.asyncio
+async def test_list_runs_returns_summary_without_heavy_payload(storage):
+    """list_runs omits the heavy payload columns; they come back as defaults, error survives."""
+    ts = datetime(2024, 1, 1, 12, 0, 0, tzinfo=UTC)
+    await _make_run(
+        storage,
+        "run_heavy",
+        ts,
+        input_args='["big"]',
+        input_kwargs='{"k": "v"}',
+        result='{"r": 1}',
+        error="boom",
+        context={"meta": "data"},
+    )
+
+    runs, _ = await storage.list_runs(limit=10)
+
+    assert len(runs) == 1
+    summary = runs[0]
+    # Heavy payload columns are not fetched -> placeholder defaults.
+    assert summary.input_args == "[]"
+    assert summary.input_kwargs == "{}"
+    assert summary.result is None
+    assert summary.context == {}
+    # Lightweight fields used by the list view survive.
+    assert summary.error == "boom"
+    assert summary.status == RunStatus.COMPLETED
+
+    # get_run still returns the full payload.
+    full = await storage.get_run("run_heavy")
+    assert full.input_args == '["big"]'
+    assert full.result == '{"r": 1}'
+    assert full.context == {"meta": "data"}

--- a/tests/unit/backends/test_postgres_storage.py
+++ b/tests/unit/backends/test_postgres_storage.py
@@ -531,6 +531,31 @@ class TestWorkflowRunOperations:
 
         assert len(runs) == 1
         assert runs[0].run_id == "run_1"
+        # list_runs returns summaries: heavy payload columns are not fetched and carry defaults,
+        # while lightweight fields (incl. error) survive. See issue #482.
+        assert runs[0].input_args == "[]"
+        assert runs[0].input_kwargs == "{}"
+        assert runs[0].result is None
+        assert runs[0].context == {}
+        assert runs[0].error is None
+
+        # The query must not SELECT * (avoids scatter-gathering wide rows across Citus shards) and
+        # must order by the keyset tuple (created_at, run_id).
+        sql = mock_conn.fetch.call_args[0][0]
+        assert "SELECT *" not in sql
+        assert "input_args" not in sql
+        assert "ORDER BY created_at DESC, run_id DESC" in sql
+
+    @pytest.mark.asyncio
+    async def test_list_runs_cursor_uses_keyset(self, mock_backend):
+        """Cursor pagination compares the (created_at, run_id) tuple, not created_at alone."""
+        backend, mock_conn = mock_backend
+        mock_conn.fetch.return_value = []
+
+        await backend.list_runs(limit=10, cursor="run_1")
+
+        sql = mock_conn.fetch.call_args[0][0]
+        assert "(created_at, run_id) <" in sql
 
 
 class TestEventOperations:

--- a/tests/unit/backends/test_sqlite_storage.py
+++ b/tests/unit/backends/test_sqlite_storage.py
@@ -478,34 +478,33 @@ class TestWorkflowRunOperations:
         """Test listing workflow runs."""
         backend, mock_conn = mock_backend
 
+        # Summary projection row: 17 columns in RUN_SUMMARY_COLUMNS order (no heavy payload cols).
         row = (
-            "run_1",
-            "test_workflow",
-            "completed",
-            "2024-01-01T12:00:00+00:00",
-            "2024-01-01T12:00:01+00:00",
-            None,
-            None,
-            "[]",
-            "{}",
-            None,
-            None,
-            None,
-            None,
-            "{}",
-            0,
-            3,
-            1,
-            None,
-            0,
-            None,
-            None,
+            "run_1",  # run_id
+            "test_workflow",  # workflow_name
+            "completed",  # status
+            "2024-01-01T12:00:00+00:00",  # created_at
+            "2024-01-01T12:00:01+00:00",  # updated_at
+            None,  # started_at
+            None,  # completed_at
+            None,  # error
+            None,  # idempotency_key
+            None,  # max_duration
+            0,  # recovery_attempts
+            3,  # max_recovery_attempts
+            1,  # recover_on_worker_loss
+            None,  # parent_run_id
+            0,  # nesting_depth
+            None,  # continued_from_run_id
+            None,  # continued_to_run_id
         )
 
+        captured_sql: list[str] = []
         mock_cursor = create_mock_cursor(fetchall_result=[row])
 
         @asynccontextmanager
-        async def mock_execute(*args, **kwargs):
+        async def mock_execute(sql, *args, **kwargs):
+            captured_sql.append(sql)
             yield mock_cursor
 
         mock_conn.execute = mock_execute
@@ -514,6 +513,13 @@ class TestWorkflowRunOperations:
 
         assert len(runs) == 1
         assert runs[0].run_id == "run_1"
+        # Heavy payload columns are not fetched -> defaults; error (lightweight) survives.
+        assert runs[0].input_args == "[]"
+        assert runs[0].result is None
+        assert runs[0].error is None
+        # No SELECT *, keyset ordering on (created_at, run_id). See issue #482.
+        assert "SELECT *" not in captured_sql[0]
+        assert "ORDER BY created_at DESC, run_id DESC" in captured_sql[0]
 
 
 class TestEventOperations:


### PR DESCRIPTION
## Summary

Fixes #482. `list_runs()` issued an unfiltered `SELECT *` with `ORDER BY created_at DESC LIMIT n+1`. On **Citus** (`workflow_runs` distributed by `run_id`), this becomes a cross-shard **scatter-gather** that pulls up to `n+1` **wide** rows — including the unbounded `input_args`/`input_kwargs`/`result`/`metadata` TEXT payloads — from every shard to the coordinator. The dashboard Runs page made it pathological (`limit=1000`, 30s polling), producing ~55s coordinator queries and dominating DB CPU/IO.

`list_runs` is a **read/observability path only** (dashboard, CLI, `health_check`). The execution engine and Celery workers look up runs by `run_id` via `get_run()`, so this change **cannot affect workflow execution**.

## Changes

**Storage** (`postgres.py` → inherited by `citus.py`, plus `mysql.py`, `sqlite.py`):
- Replace `SELECT *` with an explicit `RUN_SUMMARY_COLUMNS` projection that **drops the 4 heavy payload columns**; add `_row_to_workflow_run_summary` mappers that default them. `error` is kept (shown in the list view, normally short). `get_run()` still returns the full payload — workers/detail views unaffected. This projection is what removes the heavy payloads from the Citus scatter-gather (the dominant win).
- **Keyset pagination fix**: the old cursor compared only the non-unique `created_at`, which silently skips/duplicates rows sharing a timestamp. Now `ORDER BY created_at DESC, run_id DESC` with a `(created_at, run_id)` row-value cursor, backed by a new `idx_runs_created_at_run_id` composite index. All backends (including Citus) use the same plain composite-key index — no `INCLUDE` covering columns, to avoid duplicating the summary columns into every index leaf entry.

**Dashboard**:
- Endpoint cap `le=1000` → `le=200`.
- Runs page fetches **100/page** via a new `useRunsInfinite` cursor hook with a "Load more" control, instead of one hardcoded 1000-row fetch (the previously-plumbed-but-unused `next_cursor`).

## Tests

- Extended postgres/sqlite unit `test_list_runs` (summary defaults, `error` survives, no `SELECT *`, keyset `ORDER BY` + cursor predicate).
- New `tests/integration/test_list_runs_pagination.py`: real-SQLite **keyset regression** (5 runs sharing one timestamp paged exactly once, no skips/dupes) + summary-vs-`get_run` projection.

## Verification

- Full suite: 857 passed, 5 skipped (optional cassandra/dynamodb backends).
- `ruff check` / `ruff format --check` clean on changed files; `mypy pyworkflow` no new errors.

## Risk

**Tier 2/3 (storage)**. Component: `storage`. No `StorageBackend` ABC signature change. Touches the high-care storage backends — requests human review per CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
