### PR TITLE
fix(dashboard): migrate calendar to react-day-picker v10 (#441)

### DIFF
--- a/dashboard/frontend/package-lock.json
+++ b/dashboard/frontend/package-lock.json
@@ -44,7 +44,7 @@
         "input-otp": "^1.4.2",
         "lucide-react": "^1.16.0",
         "react": "^19.2.6",
-        "react-day-picker": "9.14.0",
+        "react-day-picker": "10.0.1",
         "react-dom": "^19.2.6",
         "react-hook-form": "^7.76.1",
         "react-top-loading-bar": "^3.0.2",
@@ -2669,15 +2669,6 @@
         "@swc/counter": "^0.1.3"
       }
     },
-    "node_modules/@tabby_ai/hijri-converter": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@tabby_ai/hijri-converter/-/hijri-converter-1.0.5.tgz",
-      "integrity": "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
     "node_modules/@tabler/icons": {
       "version": "3.44.0",
       "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.44.0.tgz",
@@ -4809,12 +4800,6 @@
         "url": "https://github.com/sponsors/kossnocorp"
       }
     },
-    "node_modules/date-fns-jalali": {
-      "version": "4.1.0-0",
-      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
-      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
-      "license": "MIT"
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -6406,15 +6391,13 @@
       }
     },
     "node_modules/react-day-picker": {
-      "version": "9.14.0",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.14.0.tgz",
-      "integrity": "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-10.0.1.tgz",
+      "integrity": "sha512-eNh6BlwcYInWaJtRv18mXQ06Ys/H6rdTZAnTaSdOYJuTpwP1JMCHNd1FDRadA+gbeinq+psdULN5Xnowy9mV8w==",
       "license": "MIT",
       "dependencies": {
         "@date-fns/tz": "^1.4.1",
-        "@tabby_ai/hijri-converter": "1.0.5",
-        "date-fns": "^4.1.0",
-        "date-fns-jalali": "4.1.0-0"
+        "date-fns": "^4.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -6424,7 +6407,13 @@
         "url": "https://github.com/sponsors/gpbl"
       },
       "peerDependencies": {
+        "@types/react": ">=16.8.0",
         "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-dom": {

--- a/dashboard/frontend/package.json
+++ b/dashboard/frontend/package.json
@@ -51,7 +51,7 @@
     "input-otp": "^1.4.2",
     "lucide-react": "^1.16.0",
     "react": "^19.2.6",
-    "react-day-picker": "9.14.0",
+    "react-day-picker": "10.0.1",
     "react-dom": "^19.2.6",
     "react-hook-form": "^7.76.1",
     "react-top-loading-bar": "^3.0.2",

--- a/dashboard/frontend/src/components/ui/calendar.tsx
+++ b/dashboard/frontend/src/components/ui/calendar.tsx
@@ -81,7 +81,10 @@ function Calendar({
             : 'rounded-md ps-2 pe-1 flex items-center gap-1 text-sm h-8 [&>svg]:text-muted-foreground [&>svg]:size-3.5',
           defaultClassNames.caption_label
         ),
-        table: 'w-full border-collapse',
+        month_grid: cn(
+          'w-full border-collapse',
+          defaultClassNames.month_grid
+        ),
         weekdays: cn('flex', defaultClassNames.weekdays),
         weekday: cn(
           'text-muted-foreground rounded-md flex-1 font-normal text-[0.8rem] select-none',


### PR DESCRIPTION
Completes the dependabot batch by landing **react-day-picker 9.14.0 → 10.0.1** (#441), which was held back from #483 because the v10 major broke the frontend build.

**Risk tier:** Tier 1. Component: `dashboard` (frontend).

## The break
v10 renames the `table` `classNames` key to **`month_grid`** (`UI.MonthGrid`). `src/components/ui/calendar.tsx` set `table: 'w-full border-collapse'`, which no longer exists in v10's `ClassNames` type:

```
src/components/ui/calendar.tsx(84,9): error TS2353: 'table' does not exist in type 'Partial<ClassNames>'.
```

## The fix
Pure rename — v10 keeps the `<table>`/`<tbody>` markup, only the key name changed. Renamed `table` → `month_grid` and composed it with `defaultClassNames.month_grid` to match the surrounding pattern. It was the **only** v10 type error project-wide; all other classNames keys and component overrides are unchanged.

Both `<Calendar>` usage sites (`date-picker.tsx`, `date-range-filter.tsx`) use stable props (`mode`, `selected`, `onSelect`, `captionLayout='dropdown'`, `defaultMonth`, `numberOfMonths`) and typecheck against v10.

## Verification
- `tsc -b` clean project-wide ✓
- `npm run build` passes ✓

Merging this closes dependabot #441 and brings open dependabot PRs to zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)