### PR TITLE
fix(celery): drop consumer connection before reschedule re-enqueue to stop self-grab

### DIFF
--- a/pyworkflow/celery/reschedule.py
+++ b/pyworkflow/celery/reschedule.py
@@ -290,7 +290,30 @@ def on_consumer_stop(consumer: Any) -> None:
         except Exception as exc:
             logger.warning(f"reschedule: failed to cancel task consumer: {exc}")
 
+    # Cancelling is not enough on the Redis transport: a BRPOP this worker already
+    # issued is accepted by the server and will still pop the *next* message pushed
+    # to those queues -- including the copy we are about to re-enqueue. The dying
+    # worker then exits before recording it in `unacked`, so the message is lost
+    # entirely (neither in the ready list nor restorable via visibility_timeout).
+    # Drop the consumer's broker connection so any in-flight BRPOP is aborted
+    # server-side *before* we re-publish; the re-enqueue itself uses the producer
+    # pool (a separate connection), so it is unaffected.
+    _abort_consumer_fetching(consumer)
+
     reschedule_inflight_on_shutdown()
+
+
+def _abort_consumer_fetching(consumer: Any) -> None:
+    """Close the consumer's broker connection to abort any in-flight BRPOP."""
+    conn = getattr(consumer, "connection", None)
+    if conn is None:
+        return
+    try:
+        # collect() tears down channels + the underlying socket, aborting the
+        # pending BRPOP. Never raises into shutdown.
+        conn.collect()
+    except Exception as exc:
+        logger.warning(f"reschedule: failed to drop consumer connection: {exc}")
 
 
 class RescheduleConsumerStep(bootsteps.StartStopStep):

--- a/tests/unit/test_reschedule.py
+++ b/tests/unit/test_reschedule.py
@@ -261,6 +261,28 @@ class TestConsumerStopHook:
         consumer.task_consumer.cancel.assert_called_once()  # stop fetching first
         task.apply_async.assert_called_once()  # then re-enqueue
 
+    def test_consumer_connection_dropped_before_reenqueue(self, fake_backend, _stopping):
+        # Cancelling the consumer is not enough on Redis: a BRPOP this worker
+        # already issued can still grab the re-enqueued copy and lose it on exit.
+        # The connection must be dropped (aborting the in-flight BRPOP) *before*
+        # the message is re-published.
+        task = _make_singleton_task()
+        fake_backend.registry[task.name] = task
+        _track(fake_backend, task, "task-1", {"run_id": "r1", "step_id": "s1"})
+
+        order = []
+        consumer = MagicMock()
+        consumer.connection.collect.side_effect = lambda *_, **__: order.append("collect")
+        task.apply_async.side_effect = lambda *_, **__: order.append("apply_async")
+
+        reschedule.on_consumer_stop(consumer)
+
+        consumer.connection.collect.assert_called_once()
+        assert order == [
+            "collect",
+            "apply_async",
+        ], "connection must be dropped before the task is re-enqueued"
+
     def test_consumer_stop_is_noop_when_not_shutting_down(self, fake_backend, monkeypatch):
         # Transient consumer restart (e.g. broker reconnect): flags are clear.
         from celery.worker import state


### PR DESCRIPTION
## Summary

Fixes the flaky CI failure in `tests/integration/test_reschedule_e2e.py::test_sigterm_reschedule_resumes_workflow` (introduced with the reschedule-on-SIGTERM feature in #488). The flakiness (~1-in-5) reflects a **real message-loss race** in the reschedule path, not a test artifact.

**Affected component:** `celery` (reschedule on worker shutdown)
**Risk tier:** Tier 3 (touches `pyworkflow/celery/`) — needs lint + type-check + full tests + review-agent + human review.

## Root cause

The feature has a dying worker cancel its task consumer and re-publish its in-flight step so a live worker resumes it within seconds. But on the Redis transport, `task_consumer.cancel()` does **not** abort a `BRPOP` the worker already issued — redis still serves the next pushed message to that pending `BRPOP`. So the dying worker grabs back the very copy it just re-enqueued, then exits before recording it in `unacked`. The message is **lost entirely**: not in the ready list, and not restorable via the broker `visibility_timeout` (3600s). The parent workflow stays `suspended` and the test (90s budget) fails.

Confirmed by inspecting Redis db state on a failing run: after the reschedule there is **no ready-list entry at all** and `unacked` holds only the original task. Every passing run has the re-enqueued message sitting in the ready list for the fresh worker.

## Fix

In `on_consumer_stop`, after cancelling the consumer, drop its broker connection (`connection.collect()`) to abort any in-flight `BRPOP` **before** re-publishing. The re-enqueue uses the producer pool (a separate connection) and the lock release uses the singleton backend, so neither is affected.

## Testing

- Stress harness with live Redis inspection: **15/15** completed (was ~1-in-5 failing)
- `test_reschedule_e2e` via pytest: **6/6** passed
- Added a unit test asserting the connection is dropped *before* the re-enqueue
- Full unit suite + reschedule/singleton/fault-tolerance integration: **889 passed**
- ruff, black, mypy clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)