### PR TITLE
fix(dashboard): remove unused Button import breaking Docker build

### DIFF
--- a/dashboard/frontend/src/features/runs/index.tsx
+++ b/dashboard/frontend/src/features/runs/index.tsx
@@ -11,7 +11,6 @@ import { GithubStarButton } from '@/components/github-star-button'
 import { ThemeSwitch } from '@/components/theme-switch'
 import { RefreshButton } from '@/components/refresh-button'
 import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
 import { useRunsInfinite, REFRESH_INTERVAL } from '@/hooks/use-runs'
 import { RunsTable } from './components/runs-table'
 


### PR DESCRIPTION
## Summary

The **Build and Publish Docker Images** workflow is failing (e.g. run on `v0.3.6`). The failure is not Docker itself — the frontend image's `npm run build` step fails at TypeScript compile:

```
src/features/runs/index.tsx(14,1): error TS6133: 'Button' is declared but its value is never read.
ERROR: process "/bin/sh -c npm run build" did not complete successfully: exit code: 2
```

`npm run build` is `tsc -b && vite build`, and `tsc` runs with `noUnusedLocals`, so an unused import is a hard error.

## Fix

Remove the unused `import { Button } from '@/components/ui/button'` in `dashboard/frontend/src/features/runs/index.tsx`. The symbol is genuinely unused — the `RefreshButton` / `GithubStarButton` references in the file are separate imports.

## Testing

- `npm run build` in `dashboard/frontend` now completes (`✓ built` — `tsc -b` clean, `vite build` succeeds). It failed at `tsc` before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)